### PR TITLE
US27Task41andTask42 Fixed missing dialog when closing the program with the x button

### DIFF
--- a/src/main/java/memoranda/ui/AppFrame.java
+++ b/src/main/java/memoranda/ui/AppFrame.java
@@ -683,16 +683,19 @@ public class AppFrame extends JFrame {
          dlg.setModal(true);
          dlg.setVisible(true);
     }
-
+    
+    // Found location of missing close dialog
+    // Dialog will now ask if you want to exit after
+    // pressing X button (if setting is enabled)
+    // It will also minimize instead of exit if
+    // ON_CLOSE is set to minimize.
+    // James Ortner (jortner1) 14-February-2018
     protected void processWindowEvent(WindowEvent e) {
         if (e.getID() == WindowEvent.WINDOW_CLOSING) {
             if (Configuration.get("ON_CLOSE").equals("exit"))
                 doExit();
             else
-	    {
-	    	exitNotify();
-		App.closeWindow();
-	    }
+            	doMinimize();
         }
         else if ((e.getID() == WindowEvent.WINDOW_ICONIFIED)) {
             super.processWindowEvent(new WindowEvent(this,


### PR DESCRIPTION
Fixes the X button to show a dialog when ON_CLOSE is set to exit. Also fixes it so that the x button minimizes the window when ON_CLOSE is set to minimize.

By default, ON_CLOSE seems to be set to minimize, this should be changeable in the preference menu which still needs to be changed to be opened when chosen in the menu bar. The default minimizing is proper behavior however. We may want to change the default behavior.